### PR TITLE
Proxy py4j java objects

### DIFF
--- a/pysparkrpc/api_client.py
+++ b/pysparkrpc/api_client.py
@@ -10,6 +10,7 @@ import httpx
 import cloudpickle
 
 import pysparkrpc
+# from pysparkrpc.proxy import ProxyJavaObject
 
 PROXY_URL = 'http://localhost:8765'
 
@@ -83,6 +84,8 @@ class APIClient(object):
                     f_func = types.FunctionType(f_code.co_consts[0], globals())
 
                     return f_func
+                elif resp['class'] == 'JavaObject':
+                    return pysparkrpc.proxy.ProxyJavaObject(_id=resp['object_id'])
                 else:
                     # don't initalize a new object if this is getting called from __init__
                     if create:

--- a/pysparkrpc/api_client.py
+++ b/pysparkrpc/api_client.py
@@ -137,9 +137,6 @@ class APIClient(object):
             v = kwargs[a]
             prepared_kwargs[a] = cls._proxy_obj_replace(v)
 
-        # prepared_args = str(base64.b64encode(pickle.dumps(args, 2)), 'utf-8')
-        # prepared_kwargs = str(base64.b64encode(pickle.dumps(kwargs, 2)), 'utf-8')
-
         return prepared_args, prepared_kwargs
 
     @classmethod

--- a/pysparkrpc/api_client.py
+++ b/pysparkrpc/api_client.py
@@ -10,7 +10,6 @@ import httpx
 import cloudpickle
 
 import pysparkrpc
-# from pysparkrpc.proxy import ProxyJavaObject
 
 PROXY_URL = 'http://localhost:8765'
 

--- a/pysparkrpc/proxy.py
+++ b/pysparkrpc/proxy.py
@@ -18,3 +18,10 @@ class Proxy(object):
             self._id = kwargs['_id']
         elif self._path and self._propclass == False:
             self._id = APIClient.call(None, self._path, None, args, kwargs, create=True)
+
+class ProxyJavaObject(Proxy):
+    def __getattr__(self, name):
+        def method(*args, **kwargs):
+            return APIClient.call(self._id, None, name, args, kwargs)
+
+        return method

--- a/tests/test_java_object.py
+++ b/tests/test_java_object.py
@@ -1,0 +1,9 @@
+import pytest
+
+sc = pytest.sc
+
+def test_java_object_hadoop_configuration():
+   sc._jsc.hadoopConfiguration().set('foo', 'bar')
+   val = sc._jsc.hadoopConfiguration().get('foo')
+
+   assert val == 'bar'


### PR DESCRIPTION
Allows the ability to call the java objects within a spark context directly. Useful for accessing the Hadoop config or other spark internals.